### PR TITLE
Mark as selected using key instead of name

### DIFF
--- a/app/src/components/misc/SelectContainer.jsx
+++ b/app/src/components/misc/SelectContainer.jsx
@@ -39,6 +39,7 @@ class SelectContainer extends React.Component {
   render() {
     const { selected, ordered, onOrderedChange } = this.props;
     const committees = this.props.committees || committeesMap;
+
     return (
       <div className={_s.component}>
         <p>Velg komiteene du ønsker å søke ved å klikke på dem{ordered && ' i prioritert rekkefølge'}.</p>
@@ -50,7 +51,7 @@ class SelectContainer extends React.Component {
                 key={key}
                 onClick={() => this.handleSelect(key)}
                 committee={committee}
-                selected={selected.some(c => c.toLowerCase() === committee.name.toLowerCase())}
+                selected={selected.some(c => c === committee.key)}
               />
             )
           )}


### PR DESCRIPTION
Use keys instead of names when selecting "cards". This fixes a bug where realfagkjelleren could not be selected due to the name not matching the key.