### PR TITLE
Rename 'Realfagkjelleren' to 'Kjelleren'

### DIFF
--- a/app/src/__tests__/__snapshots__/Routes.js.snap
+++ b/app/src/__tests__/__snapshots__/Routes.js.snap
@@ -546,7 +546,7 @@ exports[`ConnectedRoutes renders mounted root route 1`] = `
                                       Så hvis du har lyst til å prøve deg som bartender, bli kjent med andre og arrangere fester er kjelleren det perfekte stedet for deg!
                                   	  NB: Du kan få verv i både kjelleren og en annen komité, det er ikke noe problem :)",
                                     "key": "kjelleren",
-                                    "name": "Realfagskjelleren",
+                                    "name": "Kjelleren",
                                   }
                                 }
                               >
@@ -563,7 +563,7 @@ exports[`ConnectedRoutes renders mounted root route 1`] = `
                                     <h2
                                       className="name"
                                     >
-                                      Realfagskjelleren
+                                      Kjelleren
                                     </h2>
                                   </header>
                                   <div

--- a/app/src/assets/css/Selectable.scss
+++ b/app/src/assets/css/Selectable.scss
@@ -8,7 +8,7 @@
   display: inline-flex;
   max-height: 100%;
   width: 100%;
-  max-width: 8rem;
+  max-width: 5.5rem;
   align-items: center;
   flex-direction: column;
   border-radius: 2px;

--- a/app/src/common/committees.js
+++ b/app/src/common/committees.js
@@ -98,7 +98,7 @@ const committees = new Map([
   }],
   ['kjelleren', {
     key: "kjelleren",
-    name: "Realfagskjelleren",
+    name: "Kjelleren",
     info: `Realfagskjelleren er en linjeforenings bar som drives i samarbeid med linjeforeningene Spanskrøret (lektorutdanning i realfag), Delta (matematikk og fysikk) og Volvox & Alkymisten (biologi, kjemi og bioteknologi).
     Vi jobber for å få i gang fester og andre sosiale sprell for alle studentene som studerer realfag.
     Kjelleren har arrangemang både på tvers av linjeforeningene og for hver av linjeforeningene.

--- a/app/src/components/views/commitee/Application/__tests__/__snapshots__/index.js.snap
+++ b/app/src/components/views/commitee/Application/__tests__/__snapshots__/index.js.snap
@@ -142,7 +142,7 @@ exports[`Application renders correctly 1`] = `
             Så hvis du har lyst til å prøve deg som bartender, bli kjent med andre og arrangere fester er kjelleren det perfekte stedet for deg!
         	  NB: Du kan få verv i både kjelleren og en annen komité, det er ikke noe problem :)",
             "key": "kjelleren",
-            "name": "Realfagskjelleren",
+            "name": "Kjelleren",
           },
         }
       }
@@ -325,7 +325,7 @@ exports[`Application renders correctly with user info 1`] = `
             Så hvis du har lyst til å prøve deg som bartender, bli kjent med andre og arrangere fester er kjelleren det perfekte stedet for deg!
         	  NB: Du kan få verv i både kjelleren og en annen komité, det er ikke noe problem :)",
             "key": "kjelleren",
-            "name": "Realfagskjelleren",
+            "name": "Kjelleren",
           },
         }
       }
@@ -508,7 +508,7 @@ exports[`Application updates info on onChange from SelectContainer 1`] = `
             Så hvis du har lyst til å prøve deg som bartender, bli kjent med andre og arrangere fester er kjelleren det perfekte stedet for deg!
         	  NB: Du kan få verv i både kjelleren og en annen komité, det er ikke noe problem :)",
             "key": "kjelleren",
-            "name": "Realfagskjelleren",
+            "name": "Kjelleren",
           },
         }
       }
@@ -695,7 +695,7 @@ exports[`Application updates info on onChange from login 1`] = `
             Så hvis du har lyst til å prøve deg som bartender, bli kjent med andre og arrangere fester er kjelleren det perfekte stedet for deg!
         	  NB: Du kan få verv i både kjelleren og en annen komité, det er ikke noe problem :)",
             "key": "kjelleren",
-            "name": "Realfagskjelleren",
+            "name": "Kjelleren",
           },
         }
       }
@@ -878,7 +878,7 @@ exports[`Application updates user info on new props 1`] = `
             Så hvis du har lyst til å prøve deg som bartender, bli kjent med andre og arrangere fester er kjelleren det perfekte stedet for deg!
         	  NB: Du kan få verv i både kjelleren og en annen komité, det er ikke noe problem :)",
             "key": "kjelleren",
-            "name": "Realfagskjelleren",
+            "name": "Kjelleren",
           },
         }
       }

--- a/app/src/components/views/commitee/__tests__/__snapshots__/Home.js.snap
+++ b/app/src/components/views/commitee/__tests__/__snapshots__/Home.js.snap
@@ -140,7 +140,7 @@ exports[`Home renders correctly 1`] = `
             Så hvis du har lyst til å prøve deg som bartender, bli kjent med andre og arrangere fester er kjelleren det perfekte stedet for deg!
         	  NB: Du kan få verv i både kjelleren og en annen komité, det er ikke noe problem :)",
           "key": "kjelleren",
-          "name": "Realfagskjelleren",
+          "name": "Kjelleren",
         }
       }
     />


### PR DESCRIPTION
The previous name is very long and causes the "cards" for Realfagskjelleren to stretch out. This quick fix renames Realfagkjelleren to Kjelleren, which allows us to keep the 3-column layout. 